### PR TITLE
Add GitHub History to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,29 @@
+# GitHub MCP-PAI
+
+This project provides a command-line interface (CLI) for interacting with the GitHub API.
+
+## Installation
+
+```bash
+pip install github-mcp-pai
+```
+
+## Usage
+
+```python
+from github_mcp_pai import GitHub
+
+github = GitHub()
+# ...
+```
+
+## History of GitHub
+
+GitHub was founded in February 2008 by Chris Wanstrath, P. J. Hyett, and Tom Preston-Werner. It started as a way to streamline collaborative software development using Git, a distributed version control system.
+
+*   **2008:** GitHub launched and quickly gained popularity among open-source projects.
+*   **2009:** Introduced issue tracking, a crucial feature for managing bugs and feature requests.
+*   **2010:** Reached 1 million repositories hosted on the platform.
+*   **2011:** Introduced pull requests, revolutionizing the code review process.
+*   **2018:** Acquired by Microsoft for $7.5 billion.
+*   **Present:** Continues to be the leading platform for software development collaboration, hosting millions of projects and developers worldwide.


### PR DESCRIPTION
Adds a section to the README detailing the history of GitHub, from its founding to the present day.

### Changes:
```diff
--- original+++ modified@@ -0,0 +1,29 @@+# GitHub MCP-PAI
+
+This project provides a command-line interface (CLI) for interacting with the GitHub API.
+
+## Installation
+
+```bash
+pip install github-mcp-pai
+```
+
+## Usage
+
+```python
+from github_mcp_pai import GitHub
+
+github = GitHub()
+# ...
+```
+
+## History of GitHub
+
+GitHub was founded in February 2008 by Chris Wanstrath, P. J. Hyett, and Tom Preston-Werner. It started as a way to streamline collaborative software development using Git, a distributed version control system.
+
+*   **2008:** GitHub launched and quickly gained popularity among open-source projects.
+*   **2009:** Introduced issue tracking, a crucial feature for managing bugs and feature requests.
+*   **2010:** Reached 1 million repositories hosted on the platform.
+*   **2011:** Introduced pull requests, revolutionizing the code review process.
+*   **2018:** Acquired by Microsoft for $7.5 billion.
+*   **Present:** Continues to be the leading platform for software development collaboration, hosting millions of projects and developers worldwide.

```